### PR TITLE
Remove relude dependency

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
-import Relude
+import Control.Monad
+import Control.Monad.Except
 import Aws.Lambda.Runtime
 
 
@@ -9,4 +10,4 @@ main = forever $ do
   res <- runExceptT lambdaRunner
   case res of
     Right _ -> return ()
-    Left err  -> putTextLn $ show err
+    Left err  -> putStrLn $ show err

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: aws-lambda-haskell-runtime
-version: 1.0.5
+version: 1.0.6
 github: "theam/aws-lambda-haskell-runtime"
 license: Apache-2.0
 author: Nikita Tchayka
@@ -16,7 +16,7 @@ description: Please see the README on GitHub at <https://github.com/theam/aws-la
 
 dependencies:
   - base >= 4.7 && < 5
-  - relude
+  - mtl
 
 library:
   dependencies:
@@ -27,7 +27,6 @@ library:
     - directory
     - filepath
     - microlens-platform
-    - mtl
     - optparse-generic
     - process
     - template-haskell
@@ -62,7 +61,6 @@ default-extensions:
   - OverloadedStrings
   - RecordWildCards
   - ScopedTypeVariables
-  - NoImplicitPrelude
   - DeriveGeneric
   - TypeApplications
 

--- a/src/Aws/Lambda/ThHelpers.hs
+++ b/src/Aws/Lambda/ThHelpers.hs
@@ -4,18 +4,19 @@ module Aws.Lambda.ThHelpers
   , recordQ
   ) where
 
-import Relude
 import Language.Haskell.TH
+import qualified Data.Text as Text
+import Data.Text (Text)
 
 -- | Helper for defining names in declarations
 -- think of @myValue@ in @myValue = 2@
 pName :: Text -> Q Pat
-pName = pure . VarP . mkName . toString
+pName = pure . VarP . mkName . Text.unpack
 
 -- | Helper for defining names in expressions
 -- think of @myFunction@ in @quux = myFunction 3@
 eName :: Text -> Q Exp
-eName = pure . VarE . mkName . toString
+eName = pure . VarE . mkName . Text.unpack
 
 
 -- | Helper for extracting fields of a specified record
@@ -26,9 +27,9 @@ eName = pure . VarE . mkName . toString
 recordQ :: Text -> [Text] -> Q Pat
 recordQ name fields = do
   extractedFields <- traverse fName fields
-  pure $ RecP (mkName $ toString name) extractedFields
+  pure $ RecP (mkName $ Text.unpack name) extractedFields
  where
   -- | Helper for extracting fields of records
   -- think of @personAge@ in @myFunction Person { personAge = personAge } = ...@
   fName :: Text -> Q FieldPat
-  fName n = pure (mkName $ toString n, VarP $ mkName $ toString n)
+  fName n = pure (mkName $ Text.unpack n, VarP $ mkName $ Text.unpack n)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,3 @@
-import Relude
 import           Test.Hspec
 
 


### PR DESCRIPTION
I have removed the `relude` dependency given that it is not necessary to include a custom prelude and all its dependencies into the project of the users. Also, it made hard building in previous snapshots of Stackage.

For example, the tests of [serverless-haskell](https://github.com/seek-oss/serverless-haskell) failed because of this.