### PR TITLE
Fix timeout

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,24 @@
+{ compiler ? "ghc863", pkgs ? import <nixpkgs> {} }:
+
+let
+
+  haskellPackages = pkgs.haskell.packages.${compiler}.extend ( self: super: {
+  });
+
+  runtime = haskellPackages.callCabal2nix "aws-lambda-haskell-runtime" ./. {};
+
+in
+{
+  aws-lambda-haskell-runtime = runtime;
+  aws-lambda-haskell-runtime-shell = haskellPackages.shellFor {
+    packages = p: [runtime];
+    buildInputs = with pkgs; [
+      cabal-install
+      hlint
+      stack
+      haskellPackages.ghcid
+      haskellPackages.weeder
+      zlib
+    ];
+  };
+}

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: aws-lambda-haskell-runtime
-version: 1.0.9
+version: 1.0.10
 github: "theam/aws-lambda-haskell-runtime"
 license: Apache-2.0
 author: Nikita Tchayka
@@ -26,6 +26,7 @@ library:
     - conduit
     - directory
     - filepath
+    - http-client
     - microlens-platform
     - optparse-generic
     - process

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./. {}).aws-lambda-haskell-runtime-shell

--- a/src/Aws/Lambda/Runtime.hs
+++ b/src/Aws/Lambda/Runtime.hs
@@ -20,6 +20,7 @@ import Data.Monoid ((<>))
 import qualified Data.CaseInsensitive as CI
 import Lens.Micro.Platform hiding ((.=))
 import qualified Network.Wreq as Wreq
+import qualified Network.HTTP.Client as Http
 import qualified System.Environment as Environment
 import qualified System.Process as Process
 import qualified Data.UUID as UUID
@@ -132,8 +133,10 @@ readFunctionMemory = do
 
 getApiData :: Text -> App (Wreq.Response LByteString)
 getApiData endpoint =
-  keepRetrying (Wreq.get $ nextInvocationEndpoint endpoint)
+  keepRetrying (Wreq.getWith opts $ nextInvocationEndpoint endpoint)
  where
+  opts = Wreq.defaults
+         & Wreq.manager .~ Left (Http.defaultManagerSettings { Http.managerResponseTimeout = Http.responseTimeoutNone })
   keepRetrying :: IO (Wreq.Response LByteString) -> App (Wreq.Response LByteString)
   keepRetrying f = do
     result <- (liftIO $ try f) :: App (Either IOException (Wreq.Response LByteString))

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-12.13
+resolver: lts-13.0
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Apparently, lambda freezes the container when no further tasks are available. The freezing period could be longer than the request timeout, which causes the following invocation/next request to fail with a timeout error. (https://github.com/awslabs/aws-lambda-cpp/blob/master/src/runtime.cpp#L203)

This PR removes the timeout