### PR TITLE
Make writing of own runtimes easier

### DIFF
--- a/src/Aws/Lambda/Runtime.hs
+++ b/src/Aws/Lambda/Runtime.hs
@@ -23,8 +23,8 @@ import qualified Aws.Lambda.Runtime.Publish as Publish
 runLambda :: Runtime.RunCallback -> IO ()
 runLambda callback = do
   manager <- Http.newManager httpManagerSettings
+  lambdaApi <- Environment.apiEndpoint `catch` variableNotSet
   forever $ do
-    lambdaApi <- Environment.apiEndpoint `catch` variableNotSet
     event     <- ApiInfo.fetchEvent manager lambdaApi `catch` errorParsing
     context   <- Context.initialize event `catch` errorParsing `catch` variableNotSet
     ((invokeAndRun callback manager lambdaApi event context

--- a/src/Aws/Lambda/Runtime.hs
+++ b/src/Aws/Lambda/Runtime.hs
@@ -1,5 +1,6 @@
 module Aws.Lambda.Runtime
   ( runLambda
+  , Runtime.RunCallback
   , Runtime.LambdaResult(..)
   ) where
 

--- a/src/Aws/Lambda/Runtime.hs
+++ b/src/Aws/Lambda/Runtime.hs
@@ -8,9 +8,6 @@ import Control.Exception.Safe.Checked
 import Control.Monad (forever)
 import qualified Network.HTTP.Client as Http
 
-import Data.Aeson
-import qualified Data.ByteString.Lazy.Char8 as LazyByteString
-
 import qualified Aws.Lambda.Runtime.ApiInfo as ApiInfo
 import qualified Aws.Lambda.Runtime.Common as Runtime
 import qualified Aws.Lambda.Runtime.Context as Context
@@ -63,8 +60,8 @@ invokeWithCallback
 invokeWithCallback callback event context = do
   handlerName <- Environment.handlerName
   let lambdaOptions = Runtime.LambdaOptions
-                      { eventObject = LazyByteString.unpack $ ApiInfo.event event
-                      , contextObject = LazyByteString.unpack . encode $ context
+                      { eventObject = ApiInfo.event event
+                      , contextObject = context
                       , functionHandler = handlerName
                       , executionUuid = ""  -- DirectCall doesnt use UUID
                       }

--- a/src/Aws/Lambda/Runtime/ApiInfo.hs
+++ b/src/Aws/Lambda/Runtime/ApiInfo.hs
@@ -4,7 +4,6 @@ module Aws.Lambda.Runtime.ApiInfo
   ) where
 
 import qualified Control.Monad as Monad
-import qualified Text.Read as Read
 
 import Control.Exception (IOException)
 import Control.Exception.Safe.Checked
@@ -44,9 +43,9 @@ reduceEvent :: Throws Error.Parsing => Event -> (Http.HeaderName, ByteString) ->
 reduceEvent event header =
   case header of
     ("Lambda-Runtime-Deadline-Ms", value) ->
-      case Read.readMaybe $ ByteString.unpack value of
-        Just ms -> pure event { deadlineMs = ms }
-        Nothing -> throw (Error.Parsing "deadlineMs" $ ByteString.unpack value)
+      case ByteString.readInt value of
+        Just (ms, _) -> pure event { deadlineMs = ms }
+        Nothing      -> throw (Error.Parsing "deadlineMs" $ ByteString.unpack value)
 
     ("Lambda-Runtime-Trace-Id", value) ->
       pure event { traceId = ByteString.unpack value }

--- a/src/Aws/Lambda/Runtime/Common.hs
+++ b/src/Aws/Lambda/Runtime/Common.hs
@@ -4,7 +4,10 @@ module Aws.Lambda.Runtime.Common
   , LambdaOptions(..)
   ) where
 
+import Data.ByteString.Lazy (ByteString)
 import GHC.Generics (Generic)
+
+import Aws.Lambda.Runtime.Context (Context)
 
 -- | Callback that we pass to the dispatcher function
 type RunCallback =
@@ -12,12 +15,12 @@ type RunCallback =
 
 -- | Options that the generated main expects
 data LambdaOptions = LambdaOptions
-  { eventObject     :: !String
-  , contextObject   :: !String
+  { eventObject     :: !ByteString
+  , contextObject   :: !Context
   , functionHandler :: !String
   , executionUuid   :: !String
   } deriving (Generic)
 
 -- | Wrapper type to handle the result of the user
 newtype LambdaResult =
-  LambdaResult String
+  LambdaResult ByteString

--- a/src/Aws/Lambda/Runtime/Publish.hs
+++ b/src/Aws/Lambda/Runtime/Publish.hs
@@ -9,7 +9,6 @@ module Aws.Lambda.Runtime.Publish
 
 import Control.Monad (void)
 import Data.Aeson
-import qualified Data.ByteString.Char8 as ByteString
 import qualified Network.HTTP.Client as Http
 
 import qualified Aws.Lambda.Runtime.API.Endpoints as Endpoints
@@ -24,7 +23,7 @@ result (LambdaResult res) lambdaApi context manager = do
   rawRequest <- Http.parseRequest endpoint
   let request = rawRequest
                 { Http.method = "POST"
-                , Http.requestBody = Http.RequestBodyBS (ByteString.pack res)
+                , Http.requestBody = Http.RequestBodyLBS res
                 }
   void $ Http.httpNoBody request manager
 


### PR DESCRIPTION
Hey there,

I used this library to write a couple of handlers exposed via API gateway. It works really nice, but it is awfully slow. So I started to write the "runtimes" directly, i.e. I put together an executable which I put as `bootstrap` into a zip and simply use it as a provided runtime without an additional layer. That works quite nice too and is as fast as it should be. I adapted a few lines in the code in order to work with it better. Most of it involves not having to pack/unpack from different string formats but use the ones that aeson wants. Maybe you want to cherry-pick some adaptions…

Cheers
