### PR TITLE
Add module statement to the example of api gateway.

### DIFF
--- a/doc/04-usage-with-api-gateway.md
+++ b/doc/04-usage-with-api-gateway.md
@@ -59,6 +59,9 @@ Note that `HeaderName` comes from [`Network.HTTP.Simple`](https://hackage.haskel
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+
+module Lib where
+
 import GHC.Generics
 import Aws.Lambda
 import Data.Aeson


### PR DESCRIPTION
Add
```haskell
module Lib where
```
to the api gateway example in the document so readers can copy and paste.