### PR TITLE
Fix compilation errors on stackage nightly

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: aws-lambda-haskell-runtime
-version: 2.0.2
+version: 2.0.3
 github: "theam/aws-lambda-haskell-runtime"
 license: Apache-2.0
 author: Nikita Tchayka
@@ -25,7 +25,7 @@ library:
     - template-haskell
     - text
     - safe-exceptions-checked
-    - path
+    - path < 0.7
     - path-io
   source-dirs: src
   exposed-modules:

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,6 +39,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - require-0.4.2
+  - path-0.6.1
   - github: theam/tintin
     commit: 655f5a84448b001f78d833f159ac786b6c50a3cb
 # Override default flag values for local packages and extra-deps


### PR DESCRIPTION
According to https://github.com/commercialhaskell/stackage/pull/4299 , this package doesn't compile in the latest Stackage nightly build. This is because the `path` library changed the `fileExtension` function to now throw exceptions, therefore, it now returns a `m String` rather than a `String`.

I locked the dependency version to be under < 0.7 in order to allow it to compile under nightly.