### PR TITLE
Fix compatibility with path-0.7

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: aws-lambda-haskell-runtime
-version: 2.0.3
+version: 2.0.4
 github: "theam/aws-lambda-haskell-runtime"
 license: Apache-2.0
 author: Nikita Tchayka
@@ -25,7 +25,7 @@ library:
     - template-haskell
     - text
     - safe-exceptions-checked
-    - path < 0.7
+    - path > 0.7
     - path-io
   source-dirs: src
   exposed-modules:

--- a/src/Aws/Lambda/Meta/Discover.hs
+++ b/src/Aws/Lambda/Meta/Discover.hs
@@ -42,7 +42,7 @@ modulesWithHandler files =
   & Monad.filterM containsHandler
  where
   isHaskellModule file =
-    fileExtension file == ".hs"
+    fileExtension file == Just ".hs"
     && isNotIgnoredPath file
 
   isNotIgnoredPath file =

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.25
+resolver: lts-15.5
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -39,7 +39,6 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
   - require-0.4.2
-  - path-0.6.1
   - github: theam/tintin
     commit: 655f5a84448b001f78d833f159ac786b6c50a3cb
 # Override default flag values for local packages and extra-deps

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,13 +12,6 @@ packages:
   original:
     hackage: require-0.4.2
 - completed:
-    hackage: path-0.6.1@sha256:7a9a56f767a8e47b361af855fea0b4a8d18e7b029734957a65dcd5c0c1abef16,2423
-    pantry-tree:
-      size: 643
-      sha256: af9100a9534fc004de21e2615c155cd38d9012f16296ab3a394d4bcf2dc8defe
-  original:
-    hackage: path-0.6.1
-- completed:
     size: 37827
     url: https://github.com/theam/tintin/archive/655f5a84448b001f78d833f159ac786b6c50a3cb.tar.gz
     cabal-file:
@@ -34,7 +27,7 @@ packages:
     url: https://github.com/theam/tintin/archive/655f5a84448b001f78d833f159ac786b6c50a3cb.tar.gz
 snapshots:
 - completed:
-    size: 499461
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/25.yaml
-    sha256: aed98969628e20615e96b06083c933c7e3354ae56b08b75e607a26569225d6c0
-  original: lts-13.25
+    size: 491372
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/5.yaml
+    sha256: 1b549cfff328040c382a70a84a2087aac8dab6d778bf92f32a93a771a1980dfc
+  original: lts-15.5


### PR DESCRIPTION
The recent patch requires us to have a version of `path` prior to 0.7, but it would be great to support version 0.7, so we can use this package with LTS-15 and onwards.

We get `Nothing` if the file doesn't exist, so this should do the job.

Unfortunately, `path-0.7` only appears in LTS-15, so we need to bump our
Stack resolver to that in order to keep building.