### PR TITLE
More efficient context initialization

### DIFF
--- a/aws-lambda-haskell-runtime.cabal
+++ b/aws-lambda-haskell-runtime.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c21b3c988844f7c4bfb806aff4e307c5d5dc63a7973eff4a83eb329e7bccb1c9
+-- hash: f12bd3188248690adb9f0c4972dd66cb983b9057555d14205384c600255cb999
 
 name:           aws-lambda-haskell-runtime
-version:        3.0.0
+version:        3.0.1
 synopsis:       Haskell runtime for AWS Lambda
 description:    Please see the README on GitHub at <https://github.com/theam/aws-lambda-haskell-runtime#readme>
 category:       AWS

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: aws-lambda-haskell-runtime
-version: 3.0.0
+version: 3.0.1
 github: "theam/aws-lambda-haskell-runtime"
 license: Apache-2.0
 author: Nikita Tchayka


### PR DESCRIPTION
As mentioned in #75, I am not sure whether it's a safe assumption that `logStream` and `logGroup` cannot change without the lambda having to be restarted.

Regardless, even if we read `logStream` and `logGroup` every time, there's still going to be a performance improvement from not reading the other 3 environment variables.

---

A weird thing is that I benchmarked a test lambda I have with this implementation and compared it to version `2.0.6`. The differences are so staggering that I think I simply messed up the benchmarks.

![Screenshot from 2020-06-19 18-17-16](https://user-images.githubusercontent.com/18270328/85149522-10fc6a80-b25a-11ea-8b86-76238343046a.png)

![Screenshot from 2020-06-19 18-10-38](https://user-images.githubusercontent.com/18270328/85149646-34271a00-b25a-11ea-9415-24a11a29d3e3.png)

It'd be great if someone can test and verify that these differences actually make sense.

@NickSeagull could you help with benchmarking?

Edit:

I made another benchmarking attempt, this time being more careful. The differences are very insignificant, actually, but still visible.

![image](https://user-images.githubusercontent.com/18270328/85151770-dcd67900-b25c-11ea-94fb-2f2b97e09dca.png)

Closes #75