### PR TITLE
Enable users to call `runLambda`

### DIFF
--- a/src/Aws/Lambda/Runtime.hs
+++ b/src/Aws/Lambda/Runtime.hs
@@ -3,7 +3,10 @@
 
 module Aws.Lambda.Runtime
   ( runLambda
+  , Runtime.LambdaError(..)
   , Runtime.LambdaResult(..)
+  , Runtime.RunCallback
+  , Runtime.ToLambdaResponseBody(..)
   , Runtime.DispatcherStrategy(..)
   , Runtime.DispatcherOptions(..)
   , Runtime.ApiGatewayDispatcherOptions(..)


### PR DESCRIPTION
The original description of this PR related to handling JSON payloads, but as of 3.0.0 this change was not needed; however I would still like to be able to call `runLambda` without using `generateLambdaDispatcher`, and the only thing stopping this is that `LambdaError` and `ToLambdaResponseBody` are not exported.

This PR exports those types.

# Old description

See https://github.com/theam/aws-lambda-haskell-runtime/issues/77

This PR is a draft as it is primarily for discussion.

In order to handle non-JSON payloads to the lambda, this PR:
* adds `RawApiGatewayRequest` and `RawApiGatewayResponse` which are newtype wrappers over `ApiGatewayRequest` and `ApiGatewayResponse` but with FromJSON instances that don't parse the body;
* publicly exposes the types needed to write a custom `main` routine so that we can avoid the JSON decoding baked into `generateLambdaDispatcher`; and
* removes base64 support as it is not handled correctly.

The second point I would like to discuss further. I did this by necessity to get my project working, but now that I have it I don't want to go back to using `generateLambdaDispatcher` even if it did support non-JSON payloads, because of the following benefits:
* It is much simpler to relate my code to the AWS documentation, because there's a `main` I can point to and understand.
* An explicit `main` allows for initialisation setup, like reading environment variables and setting up amazonka, before the main loop commences.
* We can write higher-level wrappers for `runLambda` with more specific types, such as `runSqsLambda :: AWS.Env -> (SqsPayload -> ExceptT String AWS.AWS String) -> IO ()` which removes any doubt about what type the handler function has to be.

Moreover, with the addition of abstractions like `runSqsLambda` the number of keystrokes saved by using `generateLambdaDispatcher` is negligible at best; compare
```
main = do
  awsEnv <- AWS.newEnv AWS.Discover
  runSqsLambda awsEnv myHandler
```
versus
```
generateLambdaDispatcher StandaloneLambda defaultDispatcherOptions
-- and in another file
handler = do
  awsEnv <- AWS.newEnv AWS.Discover -- happens on every execution
  withSqsPayload awsEnv myHandler
```

(I also added a `shell.nix` so I could develop this library - take it or leave it 😊)