### PR TITLE
Fix `toJSONText` to not garble non-ASCII characters

### DIFF
--- a/src/Aws/Lambda/Utilities.hs
+++ b/src/Aws/Lambda/Utilities.hs
@@ -3,7 +3,7 @@ module Aws.Lambda.Utilities (toJSONText) where
 import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as LazyByteString
 import Data.Text
-import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 
 toJSONText :: ToJSON a => a -> Text
-toJSONText = T.pack . LazyByteString.unpack . encode
+toJSONText = T.decodeUtf8 . LazyByteString.toStrict . encode


### PR DESCRIPTION
This fixes https://github.com/theam/aws-lambda-haskell-runtime/issues/79

Using `text`s `decodeUtf8`.