### PR TITLE
Bump version to 3.0.2 (already released on hackage)

### DIFF
--- a/aws-lambda-haskell-runtime.cabal
+++ b/aws-lambda-haskell-runtime.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f12bd3188248690adb9f0c4972dd66cb983b9057555d14205384c600255cb999
+-- hash: c833537a67bfa0d976f4297649380558f7db943dcac5a1b180e2ee2401abb3f7
 
 name:           aws-lambda-haskell-runtime
-version:        3.0.1
+version:        3.0.2
 synopsis:       Haskell runtime for AWS Lambda
 description:    Please see the README on GitHub at <https://github.com/theam/aws-lambda-haskell-runtime#readme>
 category:       AWS

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: aws-lambda-haskell-runtime
-version: 3.0.1
+version: 3.0.2
 github: "theam/aws-lambda-haskell-runtime"
 license: Apache-2.0
 author: Nikita Tchayka


### PR DESCRIPTION
It looks like version `3.0.2` was released.

![image](https://user-images.githubusercontent.com/13085980/88077249-57a3f400-cb7b-11ea-9a79-888eb9517d2f.png)

But the version bump was not done or missed to commit? Here is the bump commit. Please ignore if I did understand something the wrong way.