### PR TITLE
Bugfix: Change queryStringParameters to HashMap

### DIFF
--- a/src/Aws/Lambda/Runtime/ApiGatewayInfo.hs
+++ b/src/Aws/Lambda/Runtime/ApiGatewayInfo.hs
@@ -31,7 +31,7 @@ data ApiGatewayRequest body = ApiGatewayRequest
   , apiGatewayRequestPath                  :: !Text
   , apiGatewayRequestHttpMethod            :: !Text
   , apiGatewayRequestHeaders               :: !(HashMap Text Text)
-  , apiGatewayRequestQueryStringParameters :: !(Maybe [(Text, Maybe Text)])
+  , apiGatewayRequestQueryStringParameters :: !(Maybe (HashMap Text Text))
   , apiGatewayRequestPathParameters        :: !(Maybe (HashMap Text Text))
   , apiGatewayRequestStageVariables        :: !(Maybe (HashMap Text Text))
   , apiGatewayRequestIsBase64Encoded       :: !Bool


### PR DESCRIPTION
This is to match the encoding of JSON objects. I verified it using a fork and the rest api handler starts working as expected (and not crashing) with query parameters.

Closes #85