### PR TITLE
Headers are optional on APIGatewayRequest

### DIFF
--- a/src/Aws/Lambda/Meta/Discover.hs
+++ b/src/Aws/Lambda/Meta/Discover.hs
@@ -55,7 +55,7 @@ handlerNames modules =
   & fmap (Text.pack . toFilePath)
  where
   changeExtensionToHandler file =
-    setFileExtension ".handler" file
+    replaceExtension ".handler" file
     & Maybe.fromJust  -- The path will be always parsable, as we just replace the extension
 
 containsHandler :: Path Rel File -> IO Bool

--- a/src/Aws/Lambda/Runtime/ApiGatewayInfo.hs
+++ b/src/Aws/Lambda/Runtime/ApiGatewayInfo.hs
@@ -30,7 +30,7 @@ data ApiGatewayRequest body = ApiGatewayRequest
   { apiGatewayRequestResource              :: !Text
   , apiGatewayRequestPath                  :: !Text
   , apiGatewayRequestHttpMethod            :: !Text
-  , apiGatewayRequestHeaders               :: !(HashMap Text Text)
+  , apiGatewayRequestHeaders               :: !(Maybe (HashMap Text Text))
   , apiGatewayRequestQueryStringParameters :: !(Maybe (HashMap Text Text))
   , apiGatewayRequestPathParameters        :: !(Maybe (HashMap Text Text))
   , apiGatewayRequestStageVariables        :: !(Maybe (HashMap Text Text))


### PR DESCRIPTION
API Gateway requests were failing when there are no headers