### PR TITLE
Export Aws.Lambda.Runtime.Common module

### DIFF
--- a/aws-lambda-haskell-runtime.cabal
+++ b/aws-lambda-haskell-runtime.cabal
@@ -42,7 +42,6 @@ library
       Aws.Lambda.Runtime.API.Version
       Aws.Lambda.Runtime.ApiGatewayInfo
       Aws.Lambda.Runtime.ApiInfo
-      Aws.Lambda.Runtime.Common
       Aws.Lambda.Runtime.Context
       Aws.Lambda.Runtime.Environment
       Aws.Lambda.Runtime.Error

--- a/aws-lambda-haskell-runtime.cabal
+++ b/aws-lambda-haskell-runtime.cabal
@@ -30,6 +30,7 @@ library
   exposed-modules:
       Aws.Lambda
       Aws.Lambda.Runtime
+      Aws.Lambda.Runtime.Common
   other-modules:
       Aws.Lambda.Configuration
       Aws.Lambda.Meta.Common

--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ library:
   exposed-modules:
     - Aws.Lambda
     - Aws.Lambda.Runtime
+    - Aws.Lambda.Runtime.Common
 
 tests:
   aws-lambda-haskell-runtime-test:

--- a/src/Aws/Lambda.hs
+++ b/src/Aws/Lambda.hs
@@ -6,3 +6,4 @@ import Aws.Lambda.Configuration as Reexported
 import Aws.Lambda.Runtime as Reexported
 import Aws.Lambda.Runtime.Context as Reexported
 import Aws.Lambda.Runtime.ApiGatewayInfo as Reexported
+import Aws.Lambda.Runtime.Common as Reexported


### PR DESCRIPTION
The template generation produce some code that cannot be copied and used to create custom entry points, such as multiple handlers. This is due to the `Aws.Lambda.Runtime.Common` module, which cannot be imported.
This pull request aims at exporting that module.