### PR TITLE
Now printing unchecked exceptions to the standard error stream.

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,7 @@
+cradle:
+  stack:
+    - path: "./src"
+      component: "aws-lambda-haskell-runtime:lib"
+
+    - path: "./test"
+      component: "aws-lambda-haskell-runtime:test:aws-lambda-haskell-runtime-test"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: aws-lambda-haskell-runtime
-version: 3.0.5
+version: 3.0.6
 github: "theam/aws-lambda-haskell-runtime"
 license: Apache-2.0
 author: Nikita Tchayka


### PR DESCRIPTION
This is very helpful when debugging. These errors are lost otherwise.

Leaving the `hie.yaml` because it may be useful for future contributors.