### PR TITLE
Don't double-encode standalone JSON errors

### DIFF
--- a/src/Aws/Lambda/Runtime/Error.hs
+++ b/src/Aws/Lambda/Runtime/Error.hs
@@ -7,7 +7,8 @@ module Aws.Lambda.Runtime.Error
 where
 
 import Control.Exception.Safe.Checked (Exception)
-import Data.Aeson (ToJSON (..), Value, object, (.=))
+import Data.Aeson (ToJSON (..), object, (.=))
+import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 
 newtype EnvironmentVariableNotSet
@@ -36,9 +37,5 @@ instance ToJSON Parsing where
       ]
 
 newtype Invocation
-  = Invocation Value
+  = Invocation LBS.ByteString
   deriving (Show, Exception)
-
-instance ToJSON Invocation where
-  -- We return the user error as it is
-  toJSON (Invocation err) = err

--- a/src/Aws/Lambda/Runtime/StandaloneLambda/Types.hs
+++ b/src/Aws/Lambda/Runtime/StandaloneLambda/Types.hs
@@ -9,14 +9,15 @@ module Aws.Lambda.Runtime.StandaloneLambda.Types
   )
 where
 
-import Aws.Lambda.Utilities (toJSONText)
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (ToJSON, encode)
+import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as Text
 
 -- | Wrapper type for lambda response body
-newtype StandaloneLambdaResponseBody = StandaloneLambdaResponseBody {unStandaloneLambdaResponseBody :: Text}
-  deriving newtype (ToJSON, FromJSON)
+data StandaloneLambdaResponseBody
+  = StandaloneLambdaResponseBodyPlain Text
+  | StandaloneLambdaResponseBodyJson  LBS.ByteString
 
 class ToStandaloneLambdaResponseBody a where
   toStandaloneLambdaResponse :: a -> StandaloneLambdaResponseBody
@@ -24,10 +25,10 @@ class ToStandaloneLambdaResponseBody a where
 -- We need to special case String and Text to avoid unneeded encoding
 -- which results in extra quotes put around plain text responses
 instance {-# OVERLAPPING #-} ToStandaloneLambdaResponseBody String where
-  toStandaloneLambdaResponse = StandaloneLambdaResponseBody . Text.pack
+  toStandaloneLambdaResponse = StandaloneLambdaResponseBodyPlain . Text.pack
 
 instance {-# OVERLAPPING #-} ToStandaloneLambdaResponseBody Text where
-  toStandaloneLambdaResponse = StandaloneLambdaResponseBody
+  toStandaloneLambdaResponse = StandaloneLambdaResponseBodyPlain
 
 instance ToJSON a => ToStandaloneLambdaResponseBody a where
-  toStandaloneLambdaResponse = StandaloneLambdaResponseBody . toJSONText
+  toStandaloneLambdaResponse = StandaloneLambdaResponseBodyJson . encode


### PR DESCRIPTION
Return the JSON-encoded error type instead of double-encoding it in a string in the standalone case. This lets the user specify `errorType`, `errorMessage` etc. as per the "standard AWS Lambda error format".

This also has the effect of using the potentially-faster `toEncoding` Aeson method if a user's type implements it.