### PR TITLE
Update Open Source badge to work on github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CircleCI](https://circleci.com/gh/theam/aws-lambda-haskell-runtime.svg?style=shield)](https://circleci.com/gh/theam/aws-lambda-haskell-runtime)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=shield)](http://makeapullrequest.com)
 [![Hackage version](https://img.shields.io/hackage/v/aws-lambda-haskell-runtime.svg)](https://hackage.haskell.org/package/aws-lambda-haskell-runtime)
-[![Open Source Love png1](https://badges.frapsoft.com/os/v1/open-source.png?v=103)](https://github.com/ellerbrock/open-source-badges/)
+[![Open Source Love png1](https://raw.githubusercontent.com/ellerbrock/open-source-badges/master/badges/open-source-v1/open-source.png)](https://github.com/ellerbrock/open-source-badges/)
 [![Linter](https://img.shields.io/badge/code%20style-HLint-brightgreen.svg)](https://github.com/ndmitchell/hlint)
 
 [Proceed to site](https://theam.github.io/aws-lambda-haskell-runtime) to know how to use the AWS Lambda Haskell Runtime.


### PR DESCRIPTION
So the host of the badge is disallowing requests from sources other than `github.com`; thus the change to the raw github image in their repo.

![imagen](https://user-images.githubusercontent.com/403456/137288569-44ecc796-2b7c-4bde-8f5f-985d132af4e6.png)


A proposal to allow hotlinking was made [ellerbrock/open-source-badges :: issue-17](https://github.com/ellerbrock/open-source-badges/issues/17#issuecomment-943169361).