### PR TITLE
Update Open Source badge to work on github pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,7 +449,7 @@ footer .site-generated-message
 <p><a href="https://circleci.com/gh/theam/aws-lambda-haskell-runtime"><img src="https://circleci.com/gh/theam/aws-lambda-haskell-runtime.svg?style=shield" alt="CircleCI" /></a>
 <a href="http://makeapullrequest.com"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=shield" alt="PRs Welcome" /></a>
 <a href="https://hackage.haskell.org/package/aws-lambda-haskell-runtime"><img src="https://img.shields.io/hackage/v/aws-lambda-haskell-runtime.svg" alt="Hackage version" /></a>
-<a href="https://github.com/ellerbrock/open-source-badges/"><img src="https://badges.frapsoft.com/os/v1/open-source.png?v=103" alt="Open Source Love png1" /></a>
+<a href="https://github.com/ellerbrock/open-source-badges/"><img src="https://raw.githubusercontent.com/ellerbrock/open-source-badges/master/badges/open-source-v1/open-source.png" alt="Open Source Love png1" /></a>
 <a href="https://github.com/ndmitchell/hlint"><img src="https://img.shields.io/badge/code%20style-HLint-brightgreen.svg" alt="Linter" /></a></p>
 <p><strong>aws-lambda-haskell-runtime</strong> allows you to use Haskell as a first-class citizen of AWS Lambda. It allows you to deploy projects built with Haskell, and select the handler as you would do with Node.js. It discovers which modules of the project implement a handler for AWS, and generates a dispatcher dynamically, so you don&#39;t have to worry about wiring the lambda calls, as it uses the
 handler name specified in the AWS Lambda console.</p>


### PR DESCRIPTION
Woops! I didn't realize that the `gh-pages` was not deployed from the `README.md` at https://github.com/theam/aws-lambda-haskell-runtime/pull/106