### PR TITLE
update ca-certificates so that we can install stack

### DIFF
--- a/stack-template.hsfiles
+++ b/stack-template.hsfiles
@@ -78,6 +78,8 @@ SHELL ["/bin/bash", "--rcfile", "~/.profile", "-c"]
 
 USER root
 
+RUN yum update -y ca-certificates
+
 # Installing Haskell Stack
 RUN curl -sSL https://get.haskellstack.org/ | sh
 


### PR DESCRIPTION
ca-certificates is outdated by default. Once it's updated we're able to install stack

Fixes https://github.com/theam/aws-lambda-haskell-runtime/issues/110