### PR TITLE
HandlerNotFound should be published as Runtime.HandlerNotFound

### DIFF
--- a/src/Aws/Lambda/Runtime/Error.hs
+++ b/src/Aws/Lambda/Runtime/Error.hs
@@ -2,6 +2,7 @@
 module Aws.Lambda.Runtime.Error
   ( EnvironmentVariableNotSet (..),
     Parsing (..),
+    HandlerNotFound (..),
     Invocation (..),
   )
 where
@@ -34,6 +35,16 @@ instance ToJSON Parsing where
     object
       [ "errorType" .= ("Parsing" :: Text),
         "errorMessage" .= ("Could not parse '" <> valueName <> "': " <> errorMessage)
+      ]
+
+newtype HandlerNotFound = HandlerNotFound Text
+  deriving (Show, Exception)
+
+instance ToJSON HandlerNotFound where
+  toJSON (HandlerNotFound handler) =
+    object
+      [ "errorType" .= ("Runtime.HandlerNotFound" :: Text),
+        "errorMessage" .= ("Could not find handler '" <> handler <> "'.")
       ]
 
 newtype Invocation

--- a/src/Aws/Lambda/Runtime/Publish.hs
+++ b/src/Aws/Lambda/Runtime/Publish.hs
@@ -6,6 +6,7 @@ module Aws.Lambda.Runtime.Publish
   ( result,
     invocationError,
     parsingError,
+    handlerNotFoundError,
     runtimeInitError,
   )
 where
@@ -51,6 +52,14 @@ invocationError (Error.Invocation err) lambdaApi context =
 -- | Publishes a parsing error back to AWS Lambda
 parsingError :: Error.Parsing -> Text -> Context context -> Http.Manager -> IO ()
 parsingError err lambdaApi context =
+  publish
+    (encode err)
+    (Endpoints.invocationError lambdaApi $ awsRequestId context)
+    context
+
+-- | Publishes a HandlerNotFound error back to AWS Lambda
+handlerNotFoundError :: Error.HandlerNotFound -> Text -> Context context -> Http.Manager -> IO ()
+handlerNotFoundError err lambdaApi context =
   publish
     (encode err)
     (Endpoints.invocationError lambdaApi $ awsRequestId context)

--- a/src/Aws/Lambda/Setup.hs
+++ b/src/Aws/Lambda/Setup.hs
@@ -64,6 +64,7 @@ import qualified Data.Text as Text
 import Data.Typeable (Typeable)
 import GHC.IO.Handle.FD (stderr)
 import GHC.IO.Handle.Text (hPutStr)
+import qualified Aws.Lambda.Runtime.Error as Error
 
 type Handlers handlerType m context request response error =
   HM.HashMap HandlerName (Handler handlerType m context request response error)
@@ -129,9 +130,7 @@ run dispatcherOptions mToIO handlers (LambdaOptions eventObject functionHandler 
   case HM.lookup functionHandler asIOCallbacks of
     Just handlerToCall -> handlerToCall
     Nothing ->
-      throwM $
-        userError $
-          "Could not find handler '" <> (Text.unpack . unHandlerName $ functionHandler) <> "'."
+      throwM $ Error.HandlerNotFound (unHandlerName functionHandler)
 
 addStandaloneLambdaHandler ::
   HandlerName ->


### PR DESCRIPTION
before

```
{
  "errorMessage": "RequestId: c2560dea-0377-4357-9a9d-56eb97387f97 Error: Runtime exited with error: exit status 1",
  "errorType": "Runtime.ExitError"
}
```

after

```
{
  "errorType": "Runtime.HandlerNotFound",
  "errorMessage": "Could not find handler 'handler2'."
}
```