### PR TITLE
log the error to stderr when an error is thrown

### DIFF
--- a/src/Aws/Lambda/Runtime/Configuration.hs
+++ b/src/Aws/Lambda/Runtime/Configuration.hs
@@ -1,16 +1,41 @@
+{-# LANGUAGE RankNTypes #-}
 module Aws.Lambda.Runtime.Configuration
   ( DispatcherOptions (..),
     defaultDispatcherOptions,
+    ErrorLogger,
+    flushOutput
   )
 where
 
 import Aws.Lambda.Runtime.APIGateway.Types (ApiGatewayDispatcherOptions (..))
+import Data.Text (Text)
+import Data.Text.IO (hPutStrLn)
+import Aws.Lambda.Runtime.Context
+import Aws.Lambda.Runtime.Error
+import System.IO (stderr, hFlush, stdout)
+
+type ErrorLogger = forall context. Context context -> ErrorType -> Text -> IO ()
+
+defaultErrorLogger :: ErrorLogger
+defaultErrorLogger Context {awsRequestId=requestId} errorType message = do
+  hPutStrLn stderr $ requestId <> "\t" 
+                    <> "ERROR" <> "\t" 
+                    <> toReadableType errorType <> "\t" 
+                    <> message
+  flushOutput
 
 -- | Options that the dispatcher generator expects
-newtype DispatcherOptions = DispatcherOptions
-  { apiGatewayDispatcherOptions :: ApiGatewayDispatcherOptions
+data DispatcherOptions = DispatcherOptions
+  { apiGatewayDispatcherOptions :: ApiGatewayDispatcherOptions,
+    errorLogger :: ErrorLogger
   }
 
 defaultDispatcherOptions :: DispatcherOptions
 defaultDispatcherOptions =
-  DispatcherOptions (ApiGatewayDispatcherOptions True)
+  DispatcherOptions (ApiGatewayDispatcherOptions True) defaultErrorLogger
+
+-- | Flush standard output ('stdout') and standard error output ('stderr') handlers
+flushOutput :: IO ()
+flushOutput = do
+  hFlush stdout
+  hFlush stderr

--- a/src/Aws/Lambda/Runtime/Error.hs
+++ b/src/Aws/Lambda/Runtime/Error.hs
@@ -4,6 +4,8 @@ module Aws.Lambda.Runtime.Error
     Parsing (..),
     HandlerNotFound (..),
     Invocation (..),
+    ErrorType (..),
+    toReadableType
   )
 where
 
@@ -50,3 +52,9 @@ instance ToJSON HandlerNotFound where
 newtype Invocation
   = Invocation LBS.ByteString
   deriving (Show, Exception)
+
+data ErrorType = InvocationError | InitializationError
+
+toReadableType :: ErrorType -> Text
+toReadableType InvocationError = "Invocation Error"
+toReadableType InitializationError = "Initialization Error"

--- a/src/Aws/Lambda/Runtime/Error.hs
+++ b/src/Aws/Lambda/Runtime/Error.hs
@@ -2,6 +2,7 @@
 module Aws.Lambda.Runtime.Error
   ( EnvironmentVariableNotSet (..),
     Parsing (..),
+    HandlerNotFound (..),
     Invocation (..),
   )
 where
@@ -34,6 +35,16 @@ instance ToJSON Parsing where
     object
       [ "errorType" .= ("Parsing" :: Text),
         "errorMessage" .= ("Could not parse '" <> valueName <> "': " <> errorMessage)
+      ]
+
+newtype HandlerNotFound = HandlerNotFound Text
+  deriving (Show, Exception)
+
+instance ToJSON HandlerNotFound where
+  toJSON (HandlerNotFound handler) =
+    object
+      [ "errorType" .= ("Runtime.HandlerNotFound" :: Text),
+        "errorMessage" .= ("Could not find handler '" <> handler <> "'.")
       ]
 
 newtype Invocation

--- a/src/Aws/Lambda/Runtime/Publish.hs
+++ b/src/Aws/Lambda/Runtime/Publish.hs
@@ -6,6 +6,7 @@ module Aws.Lambda.Runtime.Publish
   ( result,
     invocationError,
     parsingError,
+    handlerNotFoundError,
     runtimeInitError,
   )
 where
@@ -51,6 +52,14 @@ invocationError (Error.Invocation err) lambdaApi context =
 -- | Publishes a parsing error back to AWS Lambda
 parsingError :: Error.Parsing -> Text -> Context context -> Http.Manager -> IO ()
 parsingError err lambdaApi context =
+  publish
+    (encode err)
+    (Endpoints.invocationError lambdaApi $ awsRequestId context)
+    context
+
+-- | Publishes a HandlerNotFound error back to AWS Lambda
+handlerNotFoundError :: Error.HandlerNotFound -> Text -> Context context -> Http.Manager -> IO ()
+handlerNotFoundError err lambdaApi context =
   publish
     (encode err)
     (Endpoints.invocationError lambdaApi $ awsRequestId context)

--- a/src/Aws/Lambda/Runtime/Publish.hs
+++ b/src/Aws/Lambda/Runtime/Publish.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
 
 -- | Publishing of results/errors back to the
 -- AWS Lambda runtime API
@@ -22,6 +23,10 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text, unpack)
 import qualified Data.Text.Encoding as T
 import qualified Network.HTTP.Client as Http
+import Aws.Lambda.Runtime.Configuration
+import Aws.Lambda.Runtime.Error
+import Data.Text.Encoding (decodeUtf8)
+import Data.ByteString.Lazy (toStrict)
 
 -- | Publishes the result back to AWS Lambda
 result :: LambdaResult handlerType -> Text -> Context context -> Http.Manager -> IO ()
@@ -45,33 +50,38 @@ result lambdaResult lambdaApi context manager = do
   void $ Http.httpNoBody request manager
 
 -- | Publishes an invocation error back to AWS Lambda
-invocationError :: Error.Invocation -> Text -> Context context -> Http.Manager -> IO ()
-invocationError (Error.Invocation err) lambdaApi context =
-  publish err (Endpoints.invocationError lambdaApi $ awsRequestId context) context
+invocationError :: ErrorLogger -> Error.Invocation -> Text -> Context context -> Http.Manager -> IO ()
+invocationError logger (Error.Invocation err) lambdaApi context =
+  publish logger InvocationError err (Endpoints.invocationError lambdaApi $ awsRequestId context) context
 
 -- | Publishes a parsing error back to AWS Lambda
-parsingError :: Error.Parsing -> Text -> Context context -> Http.Manager -> IO ()
-parsingError err lambdaApi context =
+parsingError :: ErrorLogger -> Error.Parsing -> Text -> Context context -> Http.Manager -> IO ()
+parsingError logger err lambdaApi context =
   publish
+    logger
+    InvocationError
     (encode err)
     (Endpoints.invocationError lambdaApi $ awsRequestId context)
     context
 
 -- | Publishes a HandlerNotFound error back to AWS Lambda
-handlerNotFoundError :: Error.HandlerNotFound -> Text -> Context context -> Http.Manager -> IO ()
-handlerNotFoundError err lambdaApi context =
+handlerNotFoundError :: ErrorLogger -> Error.HandlerNotFound -> Text -> Context context -> Http.Manager -> IO ()
+handlerNotFoundError logger err lambdaApi context =
   publish
+    logger
+    InvocationError
     (encode err)
     (Endpoints.invocationError lambdaApi $ awsRequestId context)
     context
 
 -- | Publishes a runtime initialization error back to AWS Lambda
-runtimeInitError :: ToJSON err => err -> Text -> Context context -> Http.Manager -> IO ()
-runtimeInitError err lambdaApi =
-  publish (encode err) (Endpoints.runtimeInitError lambdaApi)
+runtimeInitError :: ToJSON err => ErrorLogger -> err -> Text -> Context context -> Http.Manager -> IO ()
+runtimeInitError logger err lambdaApi =
+  publish logger Error.InitializationError (encode err) (Endpoints.runtimeInitError lambdaApi)
 
-publish :: LBS.ByteString -> Endpoints.Endpoint -> Context context -> Http.Manager -> IO ()
-publish err (Endpoints.Endpoint endpoint) _context manager = do
+publish :: ErrorLogger -> Error.ErrorType -> LBS.ByteString -> Endpoints.Endpoint -> Context context -> Http.Manager -> IO ()
+publish logger errorType err (Endpoints.Endpoint endpoint) context manager = do
+  logger context errorType $ decodeUtf8 $ toStrict err
   rawRequest <- Http.parseRequest . unpack $ endpoint
 
   let requestBody = Http.RequestBodyLBS err

--- a/src/Aws/Lambda/Setup.hs
+++ b/src/Aws/Lambda/Setup.hs
@@ -43,7 +43,7 @@ import Aws.Lambda.Runtime.Common
     RawEventObject,
   )
 import Aws.Lambda.Runtime.Configuration
-  ( DispatcherOptions (apiGatewayDispatcherOptions),
+  ( DispatcherOptions (apiGatewayDispatcherOptions, DispatcherOptions, errorLogger),
   )
 import Aws.Lambda.Runtime.Context (Context)
 import Aws.Lambda.Runtime.StandaloneLambda.Types
@@ -114,9 +114,9 @@ runLambdaHaskellRuntime ::
   (forall a. m a -> IO a) ->
   HandlersM handlerType m context request response error () ->
   IO ()
-runLambdaHaskellRuntime options initializeContext mToIO initHandlers = do
+runLambdaHaskellRuntime options@DispatcherOptions{errorLogger=logger} initializeContext mToIO initHandlers = do
   handlers <- fmap snd . flip runStateT HM.empty . runHandlersM $ initHandlers
-  runLambda initializeContext (run options mToIO handlers)
+  runLambda logger initializeContext (run options mToIO handlers)
 
 run ::
   RuntimeContext handlerType m context request response error =>

--- a/src/Aws/Lambda/Setup.hs
+++ b/src/Aws/Lambda/Setup.hs
@@ -64,6 +64,7 @@ import qualified Data.Text as Text
 import Data.Typeable (Typeable)
 import GHC.IO.Handle.FD (stderr)
 import GHC.IO.Handle.Text (hPutStr)
+import qualified Aws.Lambda.Runtime.Error as Error
 
 type Handlers handlerType m context request response error =
   HM.HashMap HandlerName (Handler handlerType m context request response error)
@@ -129,9 +130,7 @@ run dispatcherOptions mToIO handlers (LambdaOptions eventObject functionHandler 
   case HM.lookup functionHandler asIOCallbacks of
     Just handlerToCall -> handlerToCall
     Nothing ->
-      throwM $
-        userError $
-          "Could not find handler '" <> (Text.unpack . unHandlerName $ functionHandler) <> "'."
+      throwM $ Error.HandlerNotFound (unHandlerName functionHandler)
 
 addStandaloneLambdaHandler ::
   HandlerName ->


### PR DESCRIPTION
Lambda doesn't log the error automatically when it's reported. This makes it very hard to debug when integrating with other service such as API gateway. Although users of this library can print logs anywhere they want, they cannot print the error that is thrown from the library. All uncaught errors should be printed to stderr. This aligns the behaviour of other runtime engines such as Nodejs.