### PR TITLE
fix: update stackage resolver to lts-22.11 for build compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
       - uses: haskell/actions/setup@v2
         with:
-          ghc-version: "9.0.2" # Exact version of ghc to use
+          ghc-version: "9.6.4" # Exact version of ghc to use
           # cabal-version: 'latest'. Omitted, but defaults to 'latest'
           enable-stack: true
-          stack-version: "2.9.3"
+          stack-version: "2.15.1"
 
       # Attempt to load cached dependencies
       - name: Cache Stack dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
 
       - uses: haskell/actions/setup@v2
         with:
-          ghc-version: "9.0.2" # Exact version of ghc to use
+          ghc-version: "9.6.4" # Exact version of ghc to use
           # cabal-version: 'latest'. Omitted, but defaults to 'latest'
           enable-stack: true
-          stack-version: "2.9.3"
+          stack-version: "2.15.1"
 
       # Attempt to load cached dependencies
       - name: Cache Stack dependencies

--- a/aws-lambda-haskell-runtime.cabal
+++ b/aws-lambda-haskell-runtime.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -69,7 +69,7 @@ library
     , mtl
     , path >0.7
     , path-io
-    , safe-exceptions-checked
+    , safe-exceptions
     , template-haskell
     , text
     , unordered-containers

--- a/package.yaml
+++ b/package.yaml
@@ -24,7 +24,7 @@ library:
     - http-types
     - template-haskell
     - text
-    - safe-exceptions-checked
+    - safe-exceptions
     - exceptions
     - path > 0.7
     - path-io

--- a/src/Aws/Lambda/Runtime/ApiInfo.hs
+++ b/src/Aws/Lambda/Runtime/ApiInfo.hs
@@ -6,8 +6,7 @@ where
 
 import qualified Aws.Lambda.Runtime.API.Endpoints as Endpoints
 import qualified Aws.Lambda.Runtime.Error as Error
-import Control.Exception (IOException)
-import Control.Exception.Safe.Checked
+import Control.Exception.Safe
 import qualified Control.Monad as Monad
 import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as ByteString
@@ -29,7 +28,7 @@ data Event = Event
   deriving (Show)
 
 -- | Performs a GET to the endpoint that provides the next event
-fetchEvent :: Throws Error.Parsing => Http.Manager -> Text -> IO Event
+fetchEvent :: Http.Manager -> Text -> IO Event
 fetchEvent manager lambdaApi = do
   response <- fetchApiData manager lambdaApi
   let body = Http.responseBody response
@@ -42,7 +41,7 @@ fetchApiData manager lambdaApi = do
   request <- Http.parseRequest . Text.unpack $ endpoint
   keepRetrying $ Http.httpLbs request manager
 
-reduceEvent :: Throws Error.Parsing => Event -> (Http.HeaderName, ByteString) -> IO Event
+reduceEvent :: Event -> (Http.HeaderName, ByteString) -> IO Event
 reduceEvent event header =
   case header of
     ("Lambda-Runtime-Deadline-Ms", value) ->

--- a/src/Aws/Lambda/Runtime/Context.hs
+++ b/src/Aws/Lambda/Runtime/Context.hs
@@ -7,8 +7,6 @@ where
 
 import qualified Aws.Lambda.Runtime.ApiInfo as ApiInfo
 import qualified Aws.Lambda.Runtime.Environment as Environment
-import qualified Aws.Lambda.Runtime.Error as Error
-import Control.Exception.Safe.Checked (Throws)
 import Data.IORef (IORef)
 import Data.Text (Text)
 
@@ -28,8 +26,6 @@ data Context context = Context
 
 -- | Initializes the context out of the environment
 initialize ::
-  Throws Error.Parsing =>
-  Throws Error.EnvironmentVariableNotSet =>
   IORef context ->
   IO (Context context)
 initialize customContextRef = do

--- a/src/Aws/Lambda/Runtime/Environment.hs
+++ b/src/Aws/Lambda/Runtime/Environment.hs
@@ -14,43 +14,43 @@ module Aws.Lambda.Runtime.Environment
 where
 
 import qualified Aws.Lambda.Runtime.Error as Error
-import Control.Exception.Safe.Checked (Throws, throw)
+import Control.Exception.Safe (throw)
 import Data.Text (Text, pack, unpack)
 import qualified System.Environment as Environment
 import qualified Text.Read as Read
 
-logGroupName :: Throws Error.EnvironmentVariableNotSet => IO Text
+logGroupName :: IO Text
 logGroupName =
   readEnvironmentVariable "AWS_LAMBDA_LOG_GROUP_NAME"
 
-logStreamName :: Throws Error.EnvironmentVariableNotSet => IO Text
+logStreamName :: IO Text
 logStreamName =
   readEnvironmentVariable "AWS_LAMBDA_LOG_STREAM_NAME"
 
-functionVersion :: Throws Error.EnvironmentVariableNotSet => IO Text
+functionVersion :: IO Text
 functionVersion =
   readEnvironmentVariable "AWS_LAMBDA_FUNCTION_VERSION"
 
-functionName :: Throws Error.EnvironmentVariableNotSet => IO Text
+functionName :: IO Text
 functionName =
   readEnvironmentVariable "AWS_LAMBDA_FUNCTION_NAME"
 
 setXRayTrace :: Text -> IO ()
 setXRayTrace = Environment.setEnv "_X_AMZN_TRACE_ID" . unpack
 
-taskRoot :: Throws Error.EnvironmentVariableNotSet => IO Text
+taskRoot :: IO Text
 taskRoot =
   readEnvironmentVariable "LAMBDA_TASK_ROOT"
 
-handlerName :: Throws Error.EnvironmentVariableNotSet => IO Text
+handlerName :: IO Text
 handlerName =
   readEnvironmentVariable "_HANDLER"
 
-apiEndpoint :: Throws Error.EnvironmentVariableNotSet => IO Text
+apiEndpoint :: IO Text
 apiEndpoint =
   readEnvironmentVariable "AWS_LAMBDA_RUNTIME_API"
 
-functionMemory :: Throws Error.Parsing => Throws Error.EnvironmentVariableNotSet => IO Int
+functionMemory :: IO Int
 functionMemory = do
   let envVar = "AWS_LAMBDA_FUNCTION_MEMORY_SIZE"
   memoryValue <- readEnvironmentVariable envVar
@@ -58,7 +58,7 @@ functionMemory = do
     Just value -> pure value
     Nothing -> throw (Error.Parsing envVar memoryValue envVar)
 
-readEnvironmentVariable :: Throws Error.EnvironmentVariableNotSet => Text -> IO Text
+readEnvironmentVariable :: Text -> IO Text
 readEnvironmentVariable envVar = do
   v <- Environment.lookupEnv (unpack envVar)
   case v of

--- a/src/Aws/Lambda/Runtime/Error.hs
+++ b/src/Aws/Lambda/Runtime/Error.hs
@@ -6,7 +6,7 @@ module Aws.Lambda.Runtime.Error
   )
 where
 
-import Control.Exception.Safe.Checked (Exception)
+import Control.Exception.Safe
 import Data.Aeson (ToJSON (..), object, (.=))
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-19.18
+resolver: lts-22.11
 save-hackage-creds: false
 
 # User packages to be built.
@@ -38,13 +38,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
-extra-deps:
-  - require-0.4.2
-  - cheapskate-0.1.1.2@sha256:b8ae3cbb826610ea45e6840b7fde0af2c2ea6690cb311edfe9683f61c0a50d96,3072
-  - inliterate-0.1.0@sha256:61b17ab3cef803512c264e27e463390b47af59d7d2b3a2a89bea2eac0cf84266,1853
-  - megaparsec-7.0.5@sha256:45e1f1348fab2783646fdb4d9e6097568981a740951c7356d36d794e2baba305,3902
-  - github: theam/tintin
-    commit: 4355dda4a4b3dfd8e8f5fe1764330f7f59bd25b1
+extra-deps: []
 # Override default flag values for local packages and extra-deps
 # flags: {}
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,38 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: require-0.4.2@sha256:f28dc58dd927e98a709dd926ace92704c09db34dd33a278e1d5aa22cac133984,3625
-    pantry-tree:
-      sha256: 1fe2c5947db887175c819c3a0a55d9dcbb5823d28d0a5f588ea1db2d370bd1e1
-      size: 718
-  original:
-    hackage: require-0.4.2
-- completed:
-    hackage: cheapskate-0.1.1.2@sha256:b8ae3cbb826610ea45e6840b7fde0af2c2ea6690cb311edfe9683f61c0a50d96,3072
-    pantry-tree:
-      sha256: f3d8b45723bf9851163e50b900b5397e22dca07af70c2c6145a5aea34e3a0e49
-      size: 866
-  original:
-    hackage: cheapskate-0.1.1.2@sha256:b8ae3cbb826610ea45e6840b7fde0af2c2ea6690cb311edfe9683f61c0a50d96,3072
-- completed:
-    hackage: inliterate-0.1.0@sha256:61b17ab3cef803512c264e27e463390b47af59d7d2b3a2a89bea2eac0cf84266,1853
-    pantry-tree:
-      sha256: 2cea999a63449b913f6186c3b8b276050e7a1a7195f5e94ac94fa4007da36558
-      size: 618
-  original:
-    hackage: inliterate-0.1.0@sha256:61b17ab3cef803512c264e27e463390b47af59d7d2b3a2a89bea2eac0cf84266,1853
-- completed:
-    hackage: megaparsec-7.0.5@sha256:45e1f1348fab2783646fdb4d9e6097568981a740951c7356d36d794e2baba305,3902
-    pantry-tree:
-      sha256: 1f8baf6e07326f8c8a2dd31de6b2860427f158b0892c52ba5fe9ffeb6cd3bf7f
-      size: 1428
-  original:
-    hackage: megaparsec-7.0.5@sha256:45e1f1348fab2783646fdb4d9e6097568981a740951c7356d36d794e2baba305,3902
+packages: []
 snapshots:
 - completed:
-    sha256: 65b9809265860e085b4f61d4eb00d5d73e41190693620385a69cc9d9df7a901d
-    size: 619164
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/18.yaml
-  original: lts-19.18
+    sha256: 2fdd7d3e54540062ef75ca0a73ca3a804c527dbf8a4cadafabf340e66ac4af40
+    size: 712469
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/11.yaml
+  original: lts-22.11


### PR DESCRIPTION
Avoided not being registered in stackage due to the following error.

> ```
> - aws-lambda-haskell-runtime < 0 # tried aws-lambda-haskell-runtime-4.1.2, but its *library* requires the disabled package: safe-exceptions-checked
> ```
>
> <https://github.com/commercialhaskell/stackage/blob/fb2a50c986c1dab18c5aeef5bf1e12eadcbb37f3/build-constraints.yaml#L6267C1-L6267C156>

The [safe-exceptions-checked](https://hackage.haskell.org/package/safe-exceptions-checked) library was deprecated, causing it not to build.
It has an old list of dependencies,
so I tried adding it to `extra-deps` and found that transformers, etc. require a large number of out-of-stackage-managed dependencies, causing it not to build.
I could not find any other good-looking check-exception library. Having no choice I decided to remove the check exception mechanism itself.

I believe that it should not contain any destructive changes. The removal of the check exception feature changes the type signature, but does not change the behavior,
so it is not broken unintentionally.
It is also sufficient for the user to remove the type signatures if they have been written.